### PR TITLE
Bug with subprocess and arguments

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
     <dependency>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>python-wrapper</artifactId>
-    <version>1.0.3</version>
+    <version>1.0.4</version>
   </dependency>
   </dependencies>
   

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
     <dependency>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>python-wrapper</artifactId>
-    <version>1.0.4</version>
+    <version>1.0.3</version>
   </dependency>
   </dependencies>
   

--- a/src/main/python/install_shield_builder.py
+++ b/src/main/python/install_shield_builder.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env jython
 
 import subprocess
+import shlex
 
 import hudson.model.Computer as Computer
 import hudson.Util as Util
@@ -79,7 +80,8 @@ def perform(build, launcher, listener):
     command += ' ' + arguments
     # launch InstallShield builder (ISCmdBld.exe)
     logger.println("Executing command: " + command)
-    popen = subprocess.Popen(command, shell=False,
+    command_list = shlex.split(command)
+    popen = subprocess.Popen(command_list, shell=False,
                              stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     (stdoutdata, stderrdata) = popen.communicate()
     for line in stdoutdata.splitlines():


### PR DESCRIPTION
Referencing python documentation: https://docs.python.org/2/library/subprocess.html#subprocess.Popen

subprocess.Popen uses a list of strings as first argument not a long string containing all arguments.

As it sits if you use a long list of arguments you'll end up with this failure: OSError: Cannot run program ...
